### PR TITLE
Fix typo in Battery Discharge Max Current

### DIFF
--- a/solax_modbus/const.py
+++ b/solax_modbus/const.py
@@ -182,7 +182,7 @@ SENSOR_TYPES: dict[str, list[SolaXModbusSensorEntityDescription]] = {
 		entity_registry_enabled_default=False,
     ),
 	"battery_discharge_max_current": SolaXModbusSensorEntityDescription(
-		name="Battery Disharge Max Current",
+		name="Battery Discharge Max Current",
 		key="battery_discharge_max_current",
 		native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
 	),


### PR DESCRIPTION
Hi, this is a simple PR for fixing a small typo in Battery Discharge Max Current.

Btw, many thanks for the integration you created. I spent many hours establishing a reliable connection between Solax, Eastron smart meter and Home assistant via RS485 to TCP bridge. Your solution is much better than all my experients.