### PR TITLE
Fix run mode code for Off mode + fix typo

### DIFF
--- a/solax_modbus/__init__.py
+++ b/solax_modbus/__init__.py
@@ -583,9 +583,9 @@ class SolaXModbusHub:
         elif run_modes == 2:
           self.data["run_mode"] = "Normal Mode"
         elif run_modes == 3:
-          self.data["run_mode"] = "Feedin Priority"
+          self.data["run_mode"] = "Off Mode"
         elif run_modes == 4:
-          self.data["run_mode"] = "Pemanent Fault Mode"
+          self.data["run_mode"] = "Permanent Fault Mode"
         elif run_modes == 5:
           self.data["run_mode"] = "Update Mode"
         elif run_modes == 6:


### PR DESCRIPTION
I found a mistake in run mode. When run mode code == 3, then the inverter is Off.
Number 3 is the correct value for Feedin Priority work mode (Charger Use Mode), not for inverter status.

The screenshot shows the wrong run mode when I switched the inverter off.

![image](https://user-images.githubusercontent.com/11700078/148081766-25a1af79-4dd9-4611-9e09-1b5357c245ed.png)
