### PR TITLE
Fix Inverter power scale for each phase

### DIFF
--- a/solax_modbus/__init__.py
+++ b/solax_modbus/__init__.py
@@ -761,8 +761,11 @@ class SolaXModbusHub:
         grid_current_r = decoder.decode_16bit_int()
         self.data["grid_current_r"] = round(grid_current_r * 0.1, 1)
         
+        # @todo Rename variable as it this is the invertor power on phase R, not the grid power.
+        #   The grid power is currently named as feedin_power_(rst)
+        #   (Measured Power), this quantity means what is Solax measuring via smart meter.
         grid_power_r = decoder.decode_16bit_int()
-        self.data["grid_power_r"] = round(grid_power_r * 0.1, 1)
+        self.data["grid_power_r"] = round(grid_power_r, 1)
         
         grid_frequency_r = decoder.decode_16bit_uint()
         self.data["grid_frequency_r"] = round(grid_frequency_r * 0.01, 1)
@@ -773,8 +776,9 @@ class SolaXModbusHub:
         grid_current_s = decoder.decode_16bit_int()
         self.data["grid_current_s"] = round(grid_current_s * 0.1, 1)
         
+        # @todo Rename variable.
         grid_power_s = decoder.decode_16bit_int()
-        self.data["grid_power_s"] = round(grid_power_s * 0.1, 1)
+        self.data["grid_power_s"] = round(grid_power_s, 1)
         
         grid_frequency_s = decoder.decode_16bit_uint()
         self.data["grid_frequency_s"] = round(grid_frequency_s * 0.01, 1)
@@ -785,8 +789,9 @@ class SolaXModbusHub:
         grid_current_t = decoder.decode_16bit_int()
         self.data["grid_current_t"] = round(grid_current_t * 0.1, 1)
         
+        # @todo Rename variable.
         grid_power_t = decoder.decode_16bit_int()
-        self.data["grid_power_t"] = round(grid_power_t * 0.1, 1)
+        self.data["grid_power_t"] = round(grid_power_t, 1)
         
         grid_frequency_t = decoder.decode_16bit_uint()
         self.data["grid_frequency_t"] = round(grid_frequency_t * 0.01, 1)


### PR DESCRIPTION
This PR fixes the inverter power scale for each phase.

Values for:
- Inverter Power R (register address 0x6C or 108)
- Inverter Power S
- Inverter Power T
loaded from Modbus registers are in Watts and should not be scaled by 0.1.

After this fix the formula `Inverter power R + S +T =  Inverter Power` is valid 
(`grid_power_r + grid_power_s + grid_power_t = inverter_load`).

This PR has been tested on SolaX Hybrid X3.

![image](https://user-images.githubusercontent.com/11700078/148563949-bf5e6d81-44df-476a-99b7-64d30c906ca1.png)

