### PR TITLE
Fix user limit for export control

### DIFF
--- a/solax_modbus/__init__.py
+++ b/solax_modbus/__init__.py
@@ -351,7 +351,7 @@ class SolaXModbusHub:
         self.data["export_control_factory_limit"] = round(export_control_factory_limit * 0.1, 1)
         
         export_control_user_limit = decoder.decode_16bit_uint()
-        self.data["export_control_user_limit"] = round(export_control_user_limit * 0.1, 1)
+        self.data["export_control_user_limit"] = round(export_control_user_limit * 10, 1)
         
         eps_mutes = decoder.decode_16bit_uint()
         if eps_mutes == 0:


### PR DESCRIPTION
The value in the "Export control user limit" Modbus registry is stored as (Power / 10), for example, 5200 W is stored as 520.
Therefore we must multiply the registry value by 10 to put the correct human-readable value to the sensor.solax_export_control_user_limit sensor.

Tested on SolaX X3-Hybrid-G1/G2.
I'm not sure if other SolaX types have the same problem.

