### PR TITLE
Add Battery Awaken control entity

### DIFF
--- a/solax_modbus/const.py
+++ b/solax_modbus/const.py
@@ -147,6 +147,14 @@ SELECT_TYPES = [
             3: "Both Allowed",
         }
     ],
+    ["Battery Awaken",
+        "battery_awaken",
+        0x56,
+        {
+            0: "Disable",
+            1: "Enable",
+        }
+    ],
 ]
 
 @dataclass


### PR DESCRIPTION
This PR creates a select box for controlling Battery Awaken.
I'm not sure it is the best approach for controlling this entity, maybe some switch or button would be better, but this simple solution works for me and could be useful for others.

![image](https://user-images.githubusercontent.com/11700078/150442692-07a0493d-fc3b-4564-a752-83493c741e8e.png)

Tested on SolaX X3-Hybrid-G1/G2.