### PR TITLE
Correct use mode dropdown for feed-in mosz

### DIFF
--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -573,7 +573,7 @@ SELECT_TYPES_G4 = [
 	    0x1F,
             {
                 0: "Self Use Mode",
-                1: "Feed-in Priority",
+                1: "Feedin Priority",
                 2: "Back Up Mode",
                 3: "Manual Mode",
             }


### PR DESCRIPTION
Use mode dropdown did not correctly show current settting in  feedin mode
This problem/change only applies to the Gen4 systems