### PR TITLE
Some Gen4 corrections (related  to time windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# PLEASE DO NOT USE THIS FORK, use the @wills106 main line
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
 
 [![ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/V7V51QQOL)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# PLEASE DO NOT USE THIS FORK, use the @wills106 main line
+
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration)
 
 [![ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/V7V51QQOL)

--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -378,7 +378,9 @@ class SolaXModbusHub:
             tmp = decoder.decode_16bit_uint()
             self.data["discharger_end_time_1"] = Gen4Timestring(tmp) 
             period2enable = decoder.decode_16bit_uint()
-            self.data["charge_period2_enable"] = period2enable 
+            if   period2enable == 0: self.data["charge_period2_enable"] = "Disabled"
+            elif period2enable == 1: self.data["charge_period2_enable"] = "Enabled"
+            else: self.data["charge_period2_enable"] = "Unknown"
             tmp = decoder.decode_16bit_uint()
             self.data["charger_start_time_2"] = Gen4Timestring(tmp)
             tmp = decoder.decode_16bit_uint()

--- a/custom_components/solax_modbus/const.py
+++ b/custom_components/solax_modbus/const.py
@@ -358,10 +358,11 @@ TIME_OPTIONS = {
     23: "23:00",
     3863: "23:15",
     7703: "23:30",
-    11543: "23:45",  
+    11543: "23:45", 
+    15127: "23:59", # default value for Gen4 discharger_end_time_1 , maybe not a default for Gen2,Gen3
 }
 
-TIME_OPTIONS_GEN4 = {
+TIME_OPTIONS_GEN4 = { 
     0: "00:00",
     15: "00:15",
     30: "00:30",
@@ -458,44 +459,10 @@ TIME_OPTIONS_GEN4 = {
     5903: "23:15",
     5918: "23:30",
     5933: "23:45",
+    5947: "23:59", # default value for discharger_end_time1
 }
 
-TIME_TYPES_G2 = [] # not yet implemented
-TIME_TYPES_G3 = [] # not yet implemented
-TIME_TYPES_G4 = [  # not yet used in this version
-        [   "Charger Start Time 1",
-            "charger_start_time_1",
-            0x68,
-        ],
-        [   "Charger End Time 1",
-            "charger_end_time_1",
-            0x69,
-        ],
-        [   "Disharger Start Time 1",
-            "discharger_start_time_1",
-            0x6A,
-        ],
-        [   "Disharger End Time 1",
-            "discharger_end_time_1",
-            0x6B,
-        ], 
-        [   "Charger Start Time 2",
-            "charger_start_time_2",
-            0x6D,
-        ],
-        [   "Charger End Time 2",
-            "charger_end_time_2",
-            0x6E,
-        ],
-        [   "Disharger Start Time 2",
-            "discharger_start_time_2",
-            0x6F,
-        ],
-        [   "Disharger End Time 2",
-            "discharger_end_time_2",
-            0x70,
-        ], 
-]
+
 
 SELECT_TYPES = [
 	["Charger Use Mode",
@@ -603,12 +570,12 @@ SELECT_TYPES_G4 = [
             0x69,
             TIME_OPTIONS_GEN4
         ],
-        [   "Disharger Start Time 1",
+        [   "Discharger Start Time 1",
             "discharger_start_time_1",
             0x6A,
             TIME_OPTIONS_GEN4
         ],
-        [   "Disharger End Time 1",
+        [   "Discharger End Time 1",
             "discharger_end_time_1",
             0x6B,
             TIME_OPTIONS_GEN4
@@ -623,12 +590,12 @@ SELECT_TYPES_G4 = [
             0x6E,
             TIME_OPTIONS_GEN4
         ],
-        [   "Disharger Start Time 2",
+        [   "Discharger Start Time 2",
             "discharger_start_time_2",
             0x6F,
             TIME_OPTIONS_GEN4
         ],
-        [   "Disharger End Time 2",
+        [   "Discharger End Time 2",
             "discharger_end_time_2",
             0x70,
             TIME_OPTIONS_GEN4


### PR DESCRIPTION
Added 23:59 time to the time tables, as this is the default discharge_end_time (on gen4).
Some Gen4 parameters were not displayed correctly in their select dropdown.
I also corrected some typos in the Gen4 discharge time windows.
I also removed an unused Gen4 declaration.